### PR TITLE
Fixing log description to the schemas scanned on classpath 

### DIFF
--- a/spring-cloud-schema-registry-client/src/main/java/org/springframework/cloud/schema/registry/avro/AvroSchemaRegistryClientMessageConverter.java
+++ b/spring-cloud-schema-registry-client/src/main/java/org/springframework/cloud/schema/registry/avro/AvroSchemaRegistryClientMessageConverter.java
@@ -238,9 +238,9 @@ public class AvroSchemaRegistryClientMessageConverter extends AbstractAvroMessag
 
 		Stream.of(this.schemaImports, this.schemaLocations)
 				.filter(arr -> !ObjectUtils.isEmpty(arr)).distinct().peek(resources -> {
-					this.logger.info("Scanning avro schema resources on classpath");
 					if (this.logger.isInfoEnabled()) {
-						this.logger.info("Parsing" + this.schemaImports.length);
+						this.logger.info("Scanning avro schema resources on classpath");
+						this.logger.info("Parsing " + this.schemaImports.length + " schemas");
 					}
 				}).flatMap(Arrays::stream).forEach(resource -> {
 					try {


### PR DESCRIPTION
- Fixing log description. 
- Today, It's logging something like this:
![image](https://user-images.githubusercontent.com/1019436/72671077-f06a8300-3a23-11ea-87a1-948c6bf727a4.png)