### PR TITLE
Introduce schema reference support

### DIFF
--- a/spring-cloud-schema-registry-core/src/main/java/org/springframework/cloud/schema/registry/controllers/ServerController.java
+++ b/spring-cloud-schema-registry-core/src/main/java/org/springframework/cloud/schema/registry/controllers/ServerController.java
@@ -16,9 +16,12 @@
 
 package org.springframework.cloud.schema.registry.controllers;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.springframework.cloud.schema.registry.config.SchemaServerProperties;
 import org.springframework.cloud.schema.registry.model.Schema;
@@ -38,6 +41,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -74,7 +78,9 @@ public class ServerController {
 	}
 
 	@RequestMapping(method = RequestMethod.POST, path = "/", consumes = "application/json", produces = "application/json")
-	public synchronized ResponseEntity<Schema> register(@RequestBody Schema schema, UriComponentsBuilder builder) {
+	public synchronized ResponseEntity<Schema> register(
+			@RequestHeader(value = "Schema-Reference", required = false) String schemaReferenceHeader,
+			@RequestBody Schema schema, UriComponentsBuilder builder) {
 
 		SchemaValidator validator = this.validators.get(schema.getFormat());
 
@@ -84,7 +90,13 @@ public class ServerController {
 							.collectionToCommaDelimitedString(this.validators.keySet())));
 		}
 
-		validator.validate(schema.getDefinition());
+		List<Schema> schemaReferences = null;
+
+		if (schemaReferenceHeader != null) {
+			schemaReferences = schemaReferenceResolver(schemaReferenceHeader, schema.getFormat());
+		}
+
+		validator.validate(schema.getDefinition(), schemaReferences);
 
 		Schema result;
 		List<Schema> registeredEntities = this.repository
@@ -262,6 +274,13 @@ public class ServerController {
 		return errorMessage("Invalid Schema", e);
 	}
 
+	@ExceptionHandler(NumberFormatException.class)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ResponseBody
+	public String onInvalidVersion(NumberFormatException ex) {
+		return errorMessage("Version should be a numeric value", ex);
+	}
+
 	@ExceptionHandler(SchemaNotFoundException.class)
 	@ResponseStatus(HttpStatus.NOT_FOUND)
 	@ResponseBody
@@ -274,6 +293,41 @@ public class ServerController {
 	@ResponseBody
 	public String schemaDeletionNotPermitted(SchemaDeletionNotAllowedException ex) {
 		return errorMessage("Schema deletion is not permitted", ex);
+	}
+
+	private List<Schema> schemaReferenceResolver(String schemaReferenceHeader, String format) {
+		List<Schema> schemaReferences = new ArrayList<>();
+		Schema schemaReference;
+		String subject;
+		Integer version;
+		final String schemaReferenceRegex = "(?<subject>.*)\\+v(?<version>\\d+)";
+		final Pattern schemaReferencePattern = Pattern.compile(schemaReferenceRegex);
+		Matcher schemaReferenceMatcher;
+		for (String schemaReferenceEntry : schemaReferenceHeader.split(";")) {
+			schemaReferenceMatcher = schemaReferencePattern.matcher(schemaReferenceEntry);
+			if (schemaReferenceMatcher.find()) {
+				subject = schemaReferenceMatcher.group("subject");
+				version = Integer.parseInt(schemaReferenceMatcher.group("version"));
+				schemaReference = this.repository.findOneBySubjectAndFormatAndVersion(subject, format, version);
+				if (schemaReference == null) {
+					throw new SchemaNotFoundException(
+						String.format("Could not find Schema by subject: %s, format: %s, version %s",
+								subject, format, version));
+				}
+			}
+			else {
+				subject = schemaReferenceEntry;
+				List<Schema> registeredEntities = this.repository.findBySubjectAndFormatOrderByVersion(subject, format);
+				if (registeredEntities.isEmpty()) {
+					throw new SchemaNotFoundException(
+					String.format("Could not find Schema by subject: %s, format: %s",
+							subject, format));
+				}
+				schemaReference = registeredEntities.get(0);
+			}
+			schemaReferences.add(schemaReference);
+		}
+		return schemaReferences;
 	}
 
 	private String errorMessage(String prefix, Throwable e) {

--- a/spring-cloud-schema-registry-core/src/main/java/org/springframework/cloud/schema/registry/support/AvroSchemaValidator.java
+++ b/spring-cloud-schema-registry-core/src/main/java/org/springframework/cloud/schema/registry/support/AvroSchemaValidator.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.schema.registry.support;
 
 import java.util.List;
 
+import org.apache.avro.Schema.Parser;
 import org.apache.avro.SchemaParseException;
 
 import org.springframework.cloud.schema.registry.model.Compatibility;
@@ -35,10 +36,16 @@ public class AvroSchemaValidator implements SchemaValidator {
 	public static final String AVRO_FORMAT = "avro";
 
 	@Override
-	public boolean isValid(String definition) {
+	public boolean isValid(String definition, List<Schema> schemaReferences) {
 		boolean result = true;
 		try {
-			new org.apache.avro.Schema.Parser().parse(definition);
+			Parser avroParser = new Parser();
+			if (schemaReferences != null) {
+				for (Schema schemaReference : schemaReferences) {
+					avroParser.parse(schemaReference.getDefinition());
+				}
+			}
+			avroParser.parse(definition);
 		}
 		catch (SchemaParseException ex) {
 			result = false;
@@ -47,9 +54,15 @@ public class AvroSchemaValidator implements SchemaValidator {
 	}
 
 	@Override
-	public void validate(String definition) {
+	public void validate(String definition, List<Schema> schemaReferences) {
 		try {
-			new org.apache.avro.Schema.Parser().parse(definition);
+			Parser avroParser = new Parser();
+			if (schemaReferences != null) {
+				for (Schema schemaReference : schemaReferences) {
+					avroParser.parse(schemaReference.getDefinition());
+				}
+			}
+			avroParser.parse(definition);
 		}
 		catch (SchemaParseException ex) {
 			throw new InvalidSchemaException((ex.getMessage()));

--- a/spring-cloud-schema-registry-core/src/main/java/org/springframework/cloud/schema/registry/support/SchemaValidator.java
+++ b/spring-cloud-schema-registry-core/src/main/java/org/springframework/cloud/schema/registry/support/SchemaValidator.java
@@ -35,15 +35,15 @@ public interface SchemaValidator {
 	 * @param definition - The textual representation of the schema file
 	 * @return true if valid, false otherwise
 	 */
-	boolean isValid(String definition);
+	boolean isValid(String definition, List<Schema> schemaReferences);
 
 	/**
 	 * Validates a schema definition and throws an {@link InvalidSchemaException} when the schema is invalid.
 	 * The exception is expected to have the violation description.
 	 * @param definition - The textual representation of the schema file
 	 */
-	default void validate(String definition) {
-		if (!this.isValid(definition)) {
+	default void validate(String definition, List<Schema> schemaReferences) {
+		if (!this.isValid(definition, schemaReferences)) {
 			throw new InvalidSchemaException("Invalid Schema");
 		}
 	}

--- a/spring-cloud-schema-registry-server/src/test/resources/avro_reference_definition_schema.json
+++ b/spring-cloud-schema-registry-server/src/test/resources/avro_reference_definition_schema.json
@@ -1,0 +1,11 @@
+{
+  "namespace": "example.avro",
+  "type": "record",
+  "name": "Reference",
+  "fields": [
+    {
+      "name": "user",
+      "type": "example.avro.User"
+    }
+  ]
+}


### PR DESCRIPTION
Addresses 3rd solution from #29 

Looks up optional `Schema-Reference` header that is suppose to contain referenced subjects in the following format:
1) `Schema-Reference: <referenced-subject-1>; <referenced-subject-2>; // without version`
2) `Schema-Reference: <referenced-subject>+v<version-number>;`

Example usage:
First request: 
```
$ curl --location --request POST 'http://localhost:8990' \
--header 'Content-Type: application/json' \
--data-raw '{
    "subject": "sub",
    "format": "avro",
    "definition": { # the definition is not a string for readability purposes
        "type": "record",
        "namespace": "test",
        "name": "sub",
        "fields": [
            {
                "name": "state",
                "type": "string"
            }
        ]
    }
}'
```
Response: `201 Created`

Second request (referencing `test.sub` schema):
```
$ curl --location --request POST 'http://localhost:8990' \
--header 'Content-Type: application/json' \
--header 'Schema-Reference: sub+v1' \ # referencing previously created schema by its subject
--data-raw '{
    "subject": "sub",
    "format": "avro",
    "definition": {
        "subject": "main",
        "format": "avro",
        "definition": {
            "type": "record",
            "namespace": "test",
            "name": "main",
            "fields": [
                {
                    "name": "subField",
                    "type": "test.sub"
                }
            ]
        }
    }
}'
```
Response: `201 Created`