### PR TITLE
Fix path for api call to schema registry to fetch schema by id

### DIFF
--- a/spring-cloud-schema-registry-client/src/main/java/org/springframework/cloud/schema/registry/client/ConfluentSchemaRegistryClient.java
+++ b/spring-cloud-schema-registry-client/src/main/java/org/springframework/cloud/schema/registry/client/ConfluentSchemaRegistryClient.java
@@ -150,7 +150,7 @@ public class ConfluentSchemaRegistryClient implements SchemaRegistryClient {
 
 	@Override
 	public String fetch(int id) {
-		String path = String.format("/schemas/%d", id);
+		String path = String.format("/schemas/ids/%d", id);
 		HttpHeaders headers = new HttpHeaders();
 		headers.put("Accept", ACCEPT_HEADERS);
 		headers.add("Content-Type", "application/vnd.schemaregistry.v1+json");

--- a/spring-cloud-schema-registry-client/src/test/java/org/springframework/cloud/schema/avro/client/ConfluentSchemaRegistryClientTests.java
+++ b/spring-cloud-schema-registry-client/src/test/java/org/springframework/cloud/schema/avro/client/ConfluentSchemaRegistryClientTests.java
@@ -166,4 +166,34 @@ public class ConfluentSchemaRegistryClientTests {
 		assertThat(expected.getCause() instanceof HttpStatusCodeException).isTrue();
 		this.mockRestServiceServer.verify();
 	}
+
+	@Test
+	public void fetchById() {
+		this.mockRestServiceServer
+				.expect(requestTo("http://localhost:8081/schemas/ids/1"))
+				.andExpect(method(HttpMethod.GET))
+				.andExpect(
+						header("Content-Type", "application/vnd.schemaregistry.v1+json"))
+				.andExpect(header("Accept", "application/vnd.schemaregistry.v1+json"))
+				.andRespond(withSuccess("{\"schema\":\"\"}", MediaType.APPLICATION_JSON));
+		ConfluentSchemaRegistryClient client = new ConfluentSchemaRegistryClient(
+				this.restTemplate);
+		String schema = client.fetch(1);
+		assertThat(schema).isEqualTo("");
+		this.mockRestServiceServer.verify();
+	}
+
+	@Test(expected = SchemaNotFoundException.class)
+	public void fetchByIdSchemaNotFound() {
+		this.mockRestServiceServer
+				.expect(requestTo("http://localhost:8081/schemas/ids/1"))
+				.andExpect(method(HttpMethod.GET))
+				.andExpect(
+						header("Content-Type", "application/vnd.schemaregistry.v1+json"))
+				.andExpect(header("Accept", "application/vnd.schemaregistry.v1+json"))
+				.andRespond(withStatus(HttpStatus.NOT_FOUND));
+		ConfluentSchemaRegistryClient client = new ConfluentSchemaRegistryClient(
+				this.restTemplate);
+		String schema = client.fetch(1);
+	}
 }


### PR DESCRIPTION
Schema Registry API correct endpoint: https://docs.confluent.io/current/schema-registry/develop/api.html#schemas