### PR TITLE
[GH-48] rely on schema from response

### DIFF
--- a/spring-cloud-schema-registry-client/src/main/java/org/springframework/cloud/schema/registry/SchemaRegistrationResponse.java
+++ b/spring-cloud-schema-registry-client/src/main/java/org/springframework/cloud/schema/registry/SchemaRegistrationResponse.java
@@ -21,24 +21,33 @@ package org.springframework.cloud.schema.registry;
  */
 public class SchemaRegistrationResponse {
 
-	private int id;
+    private int id;
 
-	private SchemaReference schemaReference;
+    private SchemaReference schemaReference;
 
-	public int getId() {
-		return this.id;
-	}
+    private String schema;
 
-	public void setId(int id) {
-		this.id = id;
-	}
+    public int getId() {
+        return this.id;
+    }
 
-	public SchemaReference getSchemaReference() {
-		return this.schemaReference;
-	}
+    public void setId(int id) {
+        this.id = id;
+    }
 
-	public void setSchemaReference(SchemaReference schemaReference) {
-		this.schemaReference = schemaReference;
-	}
+    public SchemaReference getSchemaReference() {
+        return this.schemaReference;
+    }
 
+    public void setSchemaReference(SchemaReference schemaReference) {
+        this.schemaReference = schemaReference;
+    }
+
+    public String getSchema() {
+        return schema;
+    }
+
+    public void setSchema(String schema) {
+        this.schema = schema;
+    }
 }

--- a/spring-cloud-schema-registry-client/src/main/java/org/springframework/cloud/schema/registry/avro/AvroSchemaRegistryClientMessageConverter.java
+++ b/spring-cloud-schema-registry-client/src/main/java/org/springframework/cloud/schema/registry/avro/AvroSchemaRegistryClientMessageConverter.java
@@ -308,8 +308,13 @@ public class AvroSchemaRegistryClientMessageConverter extends AbstractAvroMessag
 		if (parsedSchema.getRegistration() == null) {
 			SchemaRegistrationResponse response = this.schemaRegistryClient.register(toSubject(this.subjectNamePrefix, schema),
 					AVRO_FORMAT, parsedSchema.getRepresentation());
-			parsedSchema.setRegistration(response);
 
+			// rely on schema in response
+			schema = new Schema.Parser().parse(response.getSchema());
+			parsedSchema = new ParsedSchema(schema);
+			this.getCache(REFERENCE_CACHE_NAME).putIfAbsent(schema, parsedSchema);
+
+			parsedSchema.setRegistration(response);
 		}
 
 		SchemaReference schemaReference = parsedSchema.getRegistration().getSchemaReference();

--- a/spring-cloud-schema-registry-client/src/main/java/org/springframework/cloud/schema/registry/client/ConfluentSchemaRegistryClient.java
+++ b/spring-cloud-schema-registry-client/src/main/java/org/springframework/cloud/schema/registry/client/ConfluentSchemaRegistryClient.java
@@ -83,6 +83,8 @@ public class ConfluentSchemaRegistryClient implements SchemaRegistryClient {
 		String payload = null;
 		Map<String, String> maps = new HashMap<>();
 		maps.put("schema", schema);
+		SchemaRegistrationResponse schemaRegistrationResponse = new SchemaRegistrationResponse();
+		schemaRegistrationResponse.setSchema(schema);
 		try {
 			payload = this.mapper.writeValueAsString(maps);
 		}
@@ -107,6 +109,7 @@ public class ConfluentSchemaRegistryClient implements SchemaRegistryClient {
 			final List body = response.getBody();
 			if (!CollectionUtils.isEmpty(body)) {
 				version = (Integer) body.get(body.size() - 1);
+				schemaRegistrationResponse.setSchema(fetch(new SchemaReference(subject, version, "avro")));
 			}
 		}
 		catch (HttpStatusCodeException httpException) {
@@ -114,7 +117,6 @@ public class ConfluentSchemaRegistryClient implements SchemaRegistryClient {
 					subject, httpException.getStatusCode().value()), httpException);
 		}
 
-		SchemaRegistrationResponse schemaRegistrationResponse = new SchemaRegistrationResponse();
 		schemaRegistrationResponse.setId(id);
 		schemaRegistrationResponse.setSchemaReference(new SchemaReference(subject, version, "avro"));
 		return schemaRegistrationResponse;

--- a/spring-cloud-schema-registry-client/src/main/java/org/springframework/cloud/schema/registry/client/DefaultSchemaRegistryClient.java
+++ b/spring-cloud-schema-registry-client/src/main/java/org/springframework/cloud/schema/registry/client/DefaultSchemaRegistryClient.java
@@ -73,6 +73,7 @@ public class DefaultSchemaRegistryClient implements SchemaRegistryClient {
 			registrationResponse.setId((Integer) responseBody.get("id"));
 			registrationResponse.setSchemaReference(new SchemaReference(subject, (Integer) responseBody.get("version"),
 					responseBody.get("format").toString()));
+			registrationResponse.setSchema(schema);
 			return registrationResponse;
 		}
 		throw new RuntimeException(


### PR DESCRIPTION
Given the current usage, ```SchemaRegistrationResponse``` does more than just return the server response. Since we handle returning the latest version, I propose we reuse the same object for returning the corresponding schema (or pass through if unchanged).

Not sure where the best place is for testing this bit of code since it probably makes the most sense in a test against the confluent schema registry. 